### PR TITLE
Fix broken tests.

### DIFF
--- a/ArduinoLog.h
+++ b/ArduinoLog.h
@@ -16,7 +16,7 @@ Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 #include <stdarg.h>
 
 // Non standard: Arduino.h also chosen if ARDUINO is not defined. To facilitate use in non-Arduino test environments
-#if ARDUINO < 100
+#if defined(ARDUINO) && ARDUINO < 100
 	#include "WProgram.h"
 #else
 	#include "Arduino.h"
@@ -245,7 +245,7 @@ public:
 
 	/**
 	 * Output a notice message. Output message contains
-	 * N: followed by original message
+	 * I: followed by original message
 	 * Notice messages are printed out at
 	 * loglevels >= LOG_LEVEL_NOTICE
 	 * 
@@ -279,7 +279,7 @@ public:
 
 	/**
 	 * Output a trace message. Output message contains
-	 * N: followed by original message
+	 * I: followed by original message
 	 * Trace messages are printed out at
 	 * loglevels >= LOG_LEVEL_TRACE
 	 * 

--- a/examples/platformio-basic/platformio.ini
+++ b/examples/platformio-basic/platformio.ini
@@ -15,23 +15,15 @@ default_envs = adafruit_feather_m4
 platform = atmelsam
 board = adafruit_feather_m4
 framework = arduino
-lib_deps =
-    ; TODO(kendall): Remove if/when Arduino-Log is available through
-    ; PlatformIO's Library Manager
-    https://github.com/thijse/Arduino-Log.git
 test_ignore = test_native
-
+lib_deps = 
+	thijse/ArduinoLog@^1.1.1
 
 [env:native]
 platform = native
-build_flags = 
-    ; TODO(kendall): Remove if/when
-    ; https://github.com/thijse/Arduino-Log/pull/13 is merged
-	-DARDUINO=101
 lib_compat_mode = off
-lib_deps =
-    https://github.com/FabioBatSilva/ArduinoFake.git
-    ; TODO(kendall): Remove if/when Arduino-Log is available through
-    ; PlatformIO's Library Manager
-    https://github.com/thijse/Arduino-Log.git
-
+lib_deps = 
+	thijse/ArduinoLog@^1.1.1
+	fabiobatsilva/ArduinoFake@^0.2.2
+debug_test = *
+debug_build_flags = -O0 -ggdb3 -g3

--- a/examples/platformio-basic/src/main.cpp
+++ b/examples/platformio-basic/src/main.cpp
@@ -23,13 +23,15 @@ String stringValue1 = "this is a string";
 float floatValue;
 double doubleValue;
 
-void printTimestamp(Print *_logOutput) {
+void printMillis(Print *_logOutput, int unused_loglevel) {
   char c[12];
   int m = sprintf(c, "%10lu ", millis());
   _logOutput->print(c);
 }
 
-void printCarret(Print *_logOutput) { _logOutput->print('>'); }
+void printSuffix(Print *_logOutput, int unused_loglevel) {
+  _logOutput->print('>');
+}
 
 void setup() {
   // Set up serial port and wait until connected
@@ -110,8 +112,8 @@ void loop() {
   Log.verboseln(F("Log as Verbose with bool value   : %T"), boolValue2);
   Log.verbose(F("Log as Verbose with bool value   : %T" CR), boolValue2);
 
-  Log.setPrefix(printTimestamp); // set timestamp as prefix
-  Log.setSuffix(printCarret);    // set carret as suffix
+  Log.setPrefix(printMillis); // set timestamp as prefix
+  Log.setSuffix(printSuffix); // set carret as suffix
   Log.verboseln(F("Log with suffix & prefix"));
   Log.setPrefix(NULL); // set timestamp as prefix
   Log.setSuffix(NULL); // set carret as suffix

--- a/examples/platformio-basic/test/test_native.cpp
+++ b/examples/platformio-basic/test/test_native.cpp
@@ -131,7 +131,7 @@ void test_int_values() {
   Log.notice("Log as Info with integer values : %d, %d" CR, int_value1,
              int_value2);
   std::stringstream expected_output;
-  expected_output << "N: Log as Info with integer values : 173, 65536\n";
+  expected_output << "I: Log as Info with integer values : 173, 65536\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
 
@@ -144,8 +144,8 @@ void test_int_hex_values() {
   Log.notice("Log as Info with hex values     : %x, %X" CR, int_value2,
              int_value2);
   std::stringstream expected_output;
-  expected_output << "N: Log as Info with hex values     : 98, 0x0098\n"
-                  << "N: Log as Info with hex values     : fdf2, 0xfdf2\n";
+  expected_output << "I: Log as Info with hex values     : 98, 0x0098\n"
+                  << "I: Log as Info with hex values     : fdf2, 0xfdf2\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
 
@@ -156,7 +156,7 @@ void test_int_binary_values() {
   Log.notice(F("Log as Info with binary values  : %b, %B" CR), int_value1,
              int_value2);
   std::stringstream expected_output;
-  expected_output << "N: Log as Info with binary values  : 100010101010, "
+  expected_output << "I: Log as Info with binary values  : 100010101010, "
                      "0b100010110010110\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
@@ -167,7 +167,7 @@ void test_long_values() {
   Log.notice(F("Log as Info with long values    : %l, %l" CR), long_value1,
              long_value2);
   std::stringstream expected_output;
-  expected_output << "N: Log as Info with long values    : "
+  expected_output << "I: Log as Info with long values    : "
                      "34359738368, 274877906944\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
@@ -181,8 +181,8 @@ void test_bool_values() {
   Log.notice("Log as Info with bool values    : %t, %T" CR, false_value,
              false_value);
   std::stringstream expected_output;
-  expected_output << "N: Log as Info with bool values    : T, true\n";
-  expected_output << "N: Log as Info with bool values    : F, false\n";
+  expected_output << "I: Log as Info with bool values    : T, true\n";
+  expected_output << "I: Log as Info with bool values    : F, false\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
 
@@ -223,8 +223,8 @@ void test_float_values() {
   Log.notice(F("Log as Info with float value   : %F" CR), float_value);
   Log.notice("Log as Info with float value   : %F" CR, float_value);
   std::stringstream expected_output;
-  expected_output << "N: Log as Info with float value   : 12.34\n"
-                  << "N: Log as Info with float value   : 12.34\n";
+  expected_output << "I: Log as Info with float value   : 12.34\n"
+                  << "I: Log as Info with float value   : 12.34\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
 
@@ -235,8 +235,8 @@ void test_double_values() {
   Log.notice(F("Log as Info with double value   : %D" CR), double_value);
   Log.notice("Log as Info with double value   : %D" CR, double_value);
   std::stringstream expected_output;
-  expected_output << "N: Log as Info with double value   : 1234.57\n"
-                  << "N: Log as Info with double value   : 1234.57\n";
+  expected_output << "I: Log as Info with double value   : 1234.57\n"
+                  << "I: Log as Info with double value   : 1234.57\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
 
@@ -253,7 +253,7 @@ void test_mixed_values() {
              false_value);
   std::stringstream expected_output;
   expected_output
-      << "N: Log as Debug with mixed values  : 15826, 31477, 274877906944, "
+      << "I: Log as Debug with mixed values  : 15826, 31477, 274877906944, "
          "68719476743, T, false\n";
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
@@ -286,18 +286,21 @@ void test_log_levels() {
   TEST_ASSERT_EQUAL_STRING_STREAM(expected_output, output_);
 }
 
-void printTimestamp(Print *_logOutput) {
+void printMillis(Print *_logOutput, int unused_loglevel) {
   char c[12];
   int m = sprintf(c, "%10lu ", millis());
   _logOutput->print(c);
 }
-void printCarret(Print *_logOutput) { _logOutput->print('>'); }
+
+void printSuffix(Print *_logOutput, int unused_loglevel) {
+  _logOutput->print('>');
+}
 
 void test_prefix_and_suffix() {
   reset_output();
   When(Method(ArduinoFake(), millis)).Return(1026);
-  Log.setPrefix(printTimestamp); // set timestamp as prefix
-  Log.setSuffix(printCarret);    // set carret as suffix
+  Log.setPrefix(printMillis); // set millis as prefix
+  Log.setSuffix(printSuffix); // set angle bracket as suffix
   Log.verboseln(F("Log with suffix & prefix"));
   Log.setPrefix(NULL); // clear prefix
   Log.setSuffix(NULL); // clear suffix


### PR DESCRIPTION
The C Preprocessor treats undefined as 0, so WProgram.h was being
selected for unit tests. The functions used for Suffix and Prefix in the
platformio example were made using a previous version so the typedef was
incorrect. Log.notice prefixes with an I and not an N (ff0edc9).